### PR TITLE
bumped cheerio version in order to use the decodeEntities option

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,11 +22,7 @@
   "engines": {
     "node": ">= 0.8.0"
   },
-  "licenses": [
-    {
-      "type": "MIT"
-    }
-  ],
+  "license": "MIT",
   "devDependencies": {
     "grunt": "~0.4.2",
     "grunt-contrib-clean": "~0.5.0",
@@ -39,7 +35,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "cheerio": "~0.15.0",
+    "cheerio": "~0.17.0",
     "ng-directive-parser": "0.0.3"
   }
 }

--- a/tasks/ngie.js
+++ b/tasks/ngie.js
@@ -72,7 +72,7 @@ module.exports = function (grunt) {
       // load file.dest in cheerio
       var indexFilepath = file.dest;
       var indexFile = grunt.file.read(indexFilepath);
-      var $ = cheerio.load(indexFile);
+      var $ = cheerio.load(indexFile, { decodeEntities: false });
 
       // append the fix to the destTag
       $(options.destTag).append(fix);


### PR DESCRIPTION
Howdy!

We ran into an issue where HTML entities were getting decoded and breaking our app in IE.  For example:

``` html
<body ng-class="{'custom-nav': customNavbar && !embedded}">
```

would be turned into this after running ngie:

``` html
<body ng-class="{&apos;custom-nav&apos;: customNavbar &amp;&amp; !embedded}">
```

This simple patch fixes it.
